### PR TITLE
Added back SlovakIbanAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,38 @@ if (!$validator->isValid()) {
 }
 ```
 
+### Slovak IBAN
+
+Construct IBAN from Slovak account number and bank code
+
+```php
+<?php
+
+use Rikudou\Iban\Iban\SlovakIbanAdapter;
+
+$iban = new SlovakIbanAdapter('1325090010', '0900');
+
+echo $iban->asString(); // prints SK5009000000001325090010
+
+```
+
+### Slovak IBAN validator
+
+```php
+<?php
+
+use Rikudou\Iban\Iban\SlovakIbanAdapter;
+
+$iban = new SlovakIbanAdapter('1325090010', '0900');
+
+// currently returns just an instance of GenericIbanValidator
+$validator = $iban->getValidator();
+
+if (!$validator->isValid()) {
+    // do something
+}
+```
+
 ### Hungarian IBAN
 
 ```php

--- a/src/Iban/CzechAndSlovakIbanAdapter.php
+++ b/src/Iban/CzechAndSlovakIbanAdapter.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Rikudou\Iban\Iban;
+
+use Rikudou\Iban\Helper\ToStringIbanTrait;
+use Rikudou\Iban\Validator\GenericIbanValidator;
+use Rikudou\Iban\Validator\ValidatorInterface;
+
+abstract class CzechAndSlovakIbanAdapter implements IbanInterface
+{
+    use ToStringIbanTrait;
+
+    /**
+     * @var string
+     */
+    protected $accountNumber;
+
+    /**
+     * @var string
+     */
+    protected $bankCode;
+
+    /**
+     * @var string|null
+     */
+    private $iban = null;
+
+    public function __construct(string $accountNumber, string $bankCode)
+    {
+        $this->accountNumber = $accountNumber;
+        $this->bankCode = $bankCode;
+    }
+
+    /**
+     * Returns the resulting IBAN.
+     *
+     * @return string
+     */
+    public function asString(): string
+    {
+        if (is_null($this->iban)) {
+            $countryCode = $this->getCountryCode();
+            $part1 = ord($countryCode[0]) - ord('A') + 10;
+            $part2 = ord($countryCode[1]) - ord('A') + 10;
+
+            $accountPrefix = 0;
+            $accountNumber = $this->accountNumber;
+            if (strpos($accountNumber, '-') !== false) {
+                $accountParts = explode('-', $accountNumber);
+                $accountPrefix = $accountParts[0];
+                $accountNumber = $accountParts[1];
+            }
+
+            $numeric = sprintf('%04d%06s%010s%d%d00', $this->bankCode, $accountPrefix, $accountNumber, $part1, $part2);
+
+            $mod = '';
+            foreach (str_split($numeric) as $n) {
+                $mod = ($mod . $n) % 97;
+            }
+            $mod = intval($mod);
+
+            $this->iban = sprintf('%.2s%02d%04s%06s%010s', $countryCode, 98 - $mod, $this->bankCode, $accountPrefix, $accountNumber);
+        }
+
+        return $this->iban;
+    }
+
+    /**
+     * Returns the validator that checks whether the IBAN is valid.
+     *
+     * @return ValidatorInterface|null
+     */
+    public function getValidator(): ?ValidatorInterface
+    {
+        return new GenericIbanValidator($this);
+    }
+
+    abstract protected function getCountryCode(): string;
+}

--- a/src/Iban/CzechAndSlovakIbanAdapter.php
+++ b/src/Iban/CzechAndSlovakIbanAdapter.php
@@ -6,6 +6,9 @@ use Rikudou\Iban\Helper\ToStringIbanTrait;
 use Rikudou\Iban\Validator\GenericIbanValidator;
 use Rikudou\Iban\Validator\ValidatorInterface;
 
+/**
+ * @internal
+ */
 abstract class CzechAndSlovakIbanAdapter implements IbanInterface
 {
     use ToStringIbanTrait;

--- a/src/Iban/CzechIbanAdapter.php
+++ b/src/Iban/CzechIbanAdapter.php
@@ -2,80 +2,23 @@
 
 namespace Rikudou\Iban\Iban;
 
-use Rikudou\Iban\Helper\ToStringIbanTrait;
 use Rikudou\Iban\Validator\CompoundValidator;
 use Rikudou\Iban\Validator\CzechIbanValidator;
 use Rikudou\Iban\Validator\GenericIbanValidator;
 use Rikudou\Iban\Validator\ValidatorInterface;
 
-class CzechIbanAdapter implements IbanInterface
+class CzechIbanAdapter extends CzechAndSlovakIbanAdapter
 {
-    use ToStringIbanTrait;
-
-    /**
-     * @var string
-     */
-    private $accountNumber;
-
-    /**
-     * @var string
-     */
-    private $bankCode;
-
-    /**
-     * @var string|null
-     */
-    private $iban = null;
-
-    public function __construct(string $accountNumber, string $bankCode)
-    {
-        $this->accountNumber = $accountNumber;
-        $this->bankCode = $bankCode;
-    }
-
-    /**
-     * Returns the resulting IBAN.
-     *
-     * @return string
-     */
-    public function asString(): string
-    {
-        if (is_null($this->iban)) {
-            $part1 = ord('C') - ord('A') + 10;
-            $part2 = ord('Z') - ord('A') + 10;
-
-            $accountPrefix = 0;
-            $accountNumber = $this->accountNumber;
-            if (strpos($accountNumber, '-') !== false) {
-                $accountParts = explode('-', $accountNumber);
-                $accountPrefix = $accountParts[0];
-                $accountNumber = $accountParts[1];
-            }
-
-            $numeric = sprintf('%04d%06s%010s%d%d00', $this->bankCode, $accountPrefix, $accountNumber, $part1, $part2);
-
-            $mod = '';
-            foreach (str_split($numeric) as $n) {
-                $mod = ($mod . $n) % 97;
-            }
-            $mod = intval($mod);
-
-            $this->iban = sprintf('%.2s%02d%04s%06s%010s', 'CZ', 98 - $mod, $this->bankCode, $accountPrefix, $accountNumber);
-        }
-
-        return $this->iban;
-    }
-
-    /**
-     * Returns the validator that checks whether the IBAN is valid.
-     *
-     * @return ValidatorInterface|null
-     */
     public function getValidator(): ?ValidatorInterface
     {
         return new CompoundValidator(
             new CzechIbanValidator($this->accountNumber, $this->bankCode),
             new GenericIbanValidator($this)
         );
+    }
+
+    protected function getCountryCode(): string
+    {
+        return 'CZ';
     }
 }

--- a/src/Iban/SlovakIbanAdapter.php
+++ b/src/Iban/SlovakIbanAdapter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rikudou\Iban\Iban;
+
+class SlovakIbanAdapter extends CzechAndSlovakIbanAdapter
+{
+    protected function getCountryCode(): string
+    {
+        return 'SK';
+    }
+}

--- a/tests/SlovakIbanAdapterTest.php
+++ b/tests/SlovakIbanAdapterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Rikudou\Iban\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Rikudou\Iban\Iban\SlovakIbanAdapter;
+use Rikudou\Iban\Validator\ValidatorInterface;
+
+class SlovakIbanAdapterTest extends TestCase
+{
+    public function testAccountsWithoutPrefix()
+    {
+        $accounts = [
+            'SK47 7500 0000 0013 2509 0010' => [
+                'acc' => '1325090010',
+                'bank' => '7500',
+            ],
+            'SK26 0720 0000 0000 0398 3815' => [
+                'acc' => '3983815',
+                'bank' => '0720',
+            ],
+            'SK71 0200 0000 0013 2509 0061' => [
+                'acc' => '1325090061',
+                'bank' => '0200',
+            ],
+            'SK27 0900 0000 0002 8111 5217' => [
+                'acc' => '281115217',
+                'bank' => '0900',
+            ],
+            'SK67 5600 0000 0005 0011 4004' => [
+                'acc' => '500114004',
+                'bank' => '5600',
+            ],
+            'SK38 1100 0000 0029 0197 2682' => [
+                'acc' => '2901972682',
+                'bank' => '1100',
+            ],
+        ];
+
+        foreach ($accounts as $iban => $accountData) {
+            $iban = str_replace(' ', '', $iban);
+            $this->assertEquals($iban, $this->getIban($accountData['acc'], $accountData['bank'])->asString());
+            $this->assertEquals($iban, strval($this->getIban($accountData['acc'], $accountData['bank'])));
+        }
+    }
+
+    public function testAccountsWithPrefix()
+    {
+        $accounts = [
+            'SK98 7500 0010 1100 1792 9051' => [
+                'acc' => '17929051',
+                'bank' => '7500',
+                'prefix' => '1011',
+            ],
+            'SK86 0720 0210 1200 2792 4051' => [
+                'acc' => '27924051',
+                'bank' => '0720',
+                'prefix' => '21012',
+            ],
+        ];
+
+        foreach ($accounts as $iban => $accountData) {
+            $iban = str_replace(' ', '', $iban);
+            $this->assertEquals($iban, $this->getIban($accountData['acc'], $accountData['bank'], $accountData['prefix'])->asString());
+            $this->assertEquals($iban, strval($this->getIban($accountData['acc'], $accountData['bank'], $accountData['prefix'])));
+        }
+    }
+
+    public function testGetValidator()
+    {
+        $this->assertInstanceOf(ValidatorInterface::class, $this->getIban(1325090010, 7500)->getValidator());
+    }
+
+    /**
+     * @param string|int      $account
+     * @param string|int      $bankCode
+     * @param string|int|null $prefix
+     *
+     * @return SlovakIbanAdapter
+     */
+    private function getIban($account, $bankCode, $prefix = null): SlovakIbanAdapter
+    {
+        if (!is_null($prefix)) {
+            $account = "{$prefix}-{$account}";
+        }
+        $ibanAdapter = new SlovakIbanAdapter($account, $bankCode);
+
+        return $ibanAdapter;
+    }
+}


### PR DESCRIPTION
Hello, thank you for the library.
We are updating `rikudou/skqrpayment` from `2.2.1` (already 5 years old) and looks like you removed the ability to convert SK BBAN to IBAN in

https://github.com/RikudouSage/QrPaymentSK/commit/ab6f9ce76d45b875e744cf4e1968eb0c21e58f6c#diff-759146cd39d1db0166ea30871596e487fc3207596c7387409fd61cbae7a9c9fd

I ported it back. But I guess there was a reason to remove it :-)

I was thinking of doing it without inheritance but that would probably need deprecating `CzechIbanAdapter` which i wanted to avoid.
Or if you preferred to just duplicate it, use a static class for the duplication or a trait...



